### PR TITLE
Handle missing labels of prometheus alerts more gracefully

### DIFF
--- a/alertbot.py
+++ b/alertbot.py
@@ -162,14 +162,15 @@ def prometheus_alert_to_markdown(alert_data: dict) -> str:
     :return: Alert as fomatted markdown
     """
     messages = []
+    known_labels = ['alertname', 'instance', 'job']
     for alert in alert_data["alerts"]:
-        message = (
-                f"""**{alert['status']}** {'💚' if alert['status'] == 'resolved' else '🔥'}: {alert['annotations']['description']}
-* **Alertname:** {alert["labels"]['alertname']}
-* **Instance:** {alert["labels"]['instance']}
-* **Job:** {alert["labels"]['job']}
-"""
-        )
+        title = alert['annotations']['description'] if hasattr(alert['annotations'], 'description') else alert['annotations']['summary']
+        message = f"""**{alert['status']}** {'💚' if alert['status'] == 'resolved' else '🔥'}: {title}"""
+        for label_name in known_labels:
+            try:
+                message += "\n* **{0}**: {1}".format(label_name.capitalize(), alert["labels"][label_name])
+            except:
+                pass
         messages.append(message)
     return messages
 


### PR DESCRIPTION
Thanks for the great bot!

I have some alertmanager alerts without "instance"-label which cause the bot to throw exceptions, for example:
* TargetDown: https://github.com/prometheus-operator/kube-prometheus/blob/v0.12.0/manifests/kubePrometheus-prometheusRule.yaml#L16
* some alerts generated by loki: https://grafana.com/docs/loki/latest/rules/#example

The change handles missing labels more gracefully (I couldn't figure out how to do it with python f-strings).
I also added a fallback to "summary" if `annotations.description` isn't available.