### PR TITLE
fix: grafana timestamp parsing

### DIFF
--- a/alertbot.py
+++ b/alertbot.py
@@ -1,6 +1,6 @@
-import datetime
 import json
 
+import dateutil.parser
 from aiohttp.web import Request, Response, json_response
 from maubot import Plugin, MessageEvent
 from maubot.handlers import web, command
@@ -75,11 +75,11 @@ def get_alert_type(data):
 
     # Grafana
     try:
-        data["alerts"][0]["labels"]["grafana_folder"]
-        if data['status'] == "firing":
-            return "grafana-alert"
-        else:
-            return "grafana-resolved"
+        if data["alerts"][0]["labels"]["grafana_folder"]:
+            if data['status'] == "firing":
+                return "grafana-alert"
+            else:
+                return "grafana-resolved"
     except KeyError:
         pass
 
@@ -186,7 +186,6 @@ def grafana_alert_to_markdown(alert_data: dict) -> list:
     """
     messages = []
     for alert in alert_data["alerts"]:
-        datetime_format = "%Y-%m-%dT%H:%M:%S%z"
         if alert['status'] == "firing":
             message = (
                 f"""**Firing 🔥**: {alert['labels']['alertname']}  
@@ -198,8 +197,8 @@ def grafana_alert_to_markdown(alert_data: dict) -> list:
                 """
             )
         if alert['status'] == "resolved":
-            end_at = datetime.datetime.strptime(alert['endsAt'], datetime_format)
-            start_at = datetime.datetime.strptime(alert['startsAt'], datetime_format)
+            end_at = dateutil.parser.isoparse(alert['endsAt'])
+            start_at = dateutil.parser.isoparse(alert['startsAt'])
             message = (
                 f"""**Resolved 🥳**: {alert['labels']['alertname']}
     

--- a/maubot.yaml
+++ b/maubot.yaml
@@ -5,4 +5,6 @@ license: AGPL-3.0-or-later
 modules:
   - alertbot
 main_class: AlertBot
+dependencies:
+  - python-dateutil>=2.8.2,<3.0.0
 webapp: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 maubot
 aiohttp
-datetime
+python-dateutil


### PR DESCRIPTION
I stumbled across some weird timestamps (which include non iso-conform formated miliseconds) inside the json-messages from grafana:
```
{
  "receiver": "Alertbot \\+ Mail",
  "status": "resolved",
  "alerts": [
    {
      "status": "resolved",
      "labels": {
        "alertname": "Disk Usage Prometheus",
        "device": "/dev/sdb1",
        "fstype": "ext4",
        "grafana_folder": "VM Alerts",
        "instance": "redacted",
        "job": "node_exporter",
        "mountpoint": "/mnt/prometheus",
        "severity": "crit"
      },
      "annotations": {
        "grafana_state_reason": "Updated"
      },
      "startsAt": "2023-09-17T04:02:00+02:00",
      "endsAt": "2023-09-17T04:23:40.011810767+02:00",
      "generatorURL": "redacted",
      "fingerprint": "1fffae89e70514fd",
      "silenceURL": "redacted",
      "dashboardURL": "redacted",
      "panelURL": "redacted",
      "values": null,
      "valueString": "[ var='B' labels={device=/dev/sdb1, fstype=ext4, instance=redacted, job=node_exporter, mountpoint=/mnt/prometheus} value=99.04782021005579 ], [ var='C' labels={device=/dev/sdb1, fstype=ext4, instance=redacted, job=node_exporter, mountpoint=/mnt/prometheus} value=1 ]"
    }
  ],
  "groupLabels": {},
  "commonLabels": {
    "alertname": "Disk Usage Prometheus",
    "device": "/dev/sdb1",
    "fstype": "ext4",
    "grafana_folder": "VM Alerts",
    "instance": "redacted",
    "job": "node_exporter",
    "mountpoint": "/mnt/prometheus",
    "severity": "crit"
  },
  "commonAnnotations": {
    "grafana_state_reason": "Updated"
  },
  "externalURL": "redacted",
  "version": "1",
  "groupKey": "{}/{severity=~\"emerg|alert|error|crit\"}:{}",
  "truncatedAlerts": 0,
  "orgId": 1,
  "title": "[RESOLVED]  (Disk Usage Prometheus /dev/sdb1 ext4 VM Alerts redacted node_exporter /mnt/prometheus crit)",
  "state": "ok",
  "message": "**Resolved**\n\nValue: [no value]\nLabels:\n - alertname = Disk Usage Prometheus\n - device = /dev/sdb1\n - fstype = ext4\n - grafana_folder = VM Alerts\n - instance = redacted\n - job = node_exporter\n - mountpoint = /mnt/prometheus\n - severity = crit\nAnnotations:\n - grafana_state_reason = Updated\nSource: redacted\nSilence: redacted\nDashboard: redacted\nPanel: redacted\n"
}
```

 So i simplified the timestamp parsing by relying on `python-dateutil`. Now it should be irrelevant which format the timestamps have.